### PR TITLE
Update case to match parameter name

### DIFF
--- a/VoxelSpace.html
+++ b/VoxelSpace.html
@@ -441,7 +441,7 @@ function DownloadImagesAsync(urls, OnSuccess) {
     var pending = urls.length;
     var result = [];
     if (pending === 0) {
-        setTimeout(onsuccess.bind(null, result), 0);
+        setTimeout(OnSuccess.bind(null, result), 0);
         return;
     }
     urls.forEach(function(url, i) {


### PR DESCRIPTION
It looks like a simple typo was made and `onsuccess` should be `OnSuccess`